### PR TITLE
MARP-2597 Add E2E workflow and test environment support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,11 @@ on:
     - cron:  '21 21 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6
-    secrets:
-      mvnArgs: -Ds4hana.baseUrl=${{secrets.BASE_URL}} -Ds4hana.apiKey=${{secrets.API_KEY}}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,8 +6,10 @@ on:
     - cron:  '21 21 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v6
-    secrets:
-      mvnArgs: -Ds4hana.baseUrl=${{secrets.BASE_URL}} -Ds4hana.apiKey=${{secrets.API_KEY}}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,4 +13,4 @@ jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6
     secrets:
-      mvnArgs: -Ds4hana.baseUrl=${{secrets.BASE_URL}} -Ds4hana.apiKey=${{secrets.API_KEY}} "-DtestEnvironment=${{ secrets.END_2_END_TESTING_ENV }}"
+      mvnArgs: -Ds4hana.baseUrl=${{secrets.BASE_URL}} -Ds4hana.apiKey=${{secrets.API_KEY}} -DtestEnvironment=E2E

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,16 @@
+name: E2E-Build
+
+on:
+  schedule:
+    - cron:  '0 1 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  build:
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6
+    secrets:
+      mvnArgs: -Ds4hana.baseUrl=${{secrets.BASE_URL}} -Ds4hana.apiKey=${{secrets.API_KEY}} "-DtestEnvironment=${{ secrets.END_2_END_TESTING_ENV }}"

--- a/S4HANA-test/pom.xml
+++ b/S4HANA-test/pom.xml
@@ -77,6 +77,7 @@
             <systemPropertyVariables>
               <baseUrl>${s4hana.baseUrl}</baseUrl>
               <apiKey>${s4hana.apiKey}</apiKey>
+              <testEnvironment>${testEnvironment}</testEnvironment>
             </systemPropertyVariables>
             <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
               <disable>false</disable>

--- a/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/constants/S4HanaTestConstants.java
+++ b/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/constants/S4HanaTestConstants.java
@@ -5,6 +5,6 @@ public class S4HanaTestConstants {
 	public static final String REAL_CALL_CONTEXT_DISPLAY_NAME = "Real Server Test";
 	public static final String BASE_URL = "baseUrl";
 	public static final String API_KEY = "apiKey";
-		public static final String END_TO_END_TESTING_ENVIRONMENT_KEY = "testEnvironment";
+	public static final String END_TO_END_TESTING_ENVIRONMENT_KEY = "testEnvironment";
 	public static final String END_TO_END_TESTING_ENVIRONMENT_VALUE = "E2E Testing";
 }

--- a/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/constants/S4HanaTestConstants.java
+++ b/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/constants/S4HanaTestConstants.java
@@ -6,5 +6,5 @@ public class S4HanaTestConstants {
 	public static final String BASE_URL = "baseUrl";
 	public static final String API_KEY = "apiKey";
 	public static final String END_TO_END_TESTING_ENVIRONMENT_KEY = "testEnvironment";
-	public static final String END_TO_END_TESTING_ENVIRONMENT_VALUE = "E2E Testing";
+	public static final String END_TO_END_TESTING_ENVIRONMENT_VALUE = "E2E";
 }

--- a/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/constants/S4HanaTestConstants.java
+++ b/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/constants/S4HanaTestConstants.java
@@ -5,4 +5,6 @@ public class S4HanaTestConstants {
 	public static final String REAL_CALL_CONTEXT_DISPLAY_NAME = "Real Server Test";
 	public static final String BASE_URL = "baseUrl";
 	public static final String API_KEY = "apiKey";
+		public static final String END_TO_END_TESTING_ENVIRONMENT_KEY = "testEnvironment";
+	public static final String END_TO_END_TESTING_ENVIRONMENT_VALUE = "E2E Testing";
 }

--- a/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/context/MultiEnvironmentContextProvider.java
+++ b/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/context/MultiEnvironmentContextProvider.java
@@ -20,9 +20,9 @@ public class MultiEnvironmentContextProvider implements TestTemplateInvocationCo
 		String testEnv = System.getProperty(S4HanaTestConstants.END_TO_END_TESTING_ENVIRONMENT_KEY);
 		return switch (testEnv) {
 		case S4HanaTestConstants.END_TO_END_TESTING_ENVIRONMENT_VALUE ->
-			Stream.of(new TestEnironmentInvocationContext(S4HanaTestConstants.REAL_CALL_CONTEXT_DISPLAY_NAME));
+			Stream.of(new TestEnvironmentInvocationContext(S4HanaTestConstants.REAL_CALL_CONTEXT_DISPLAY_NAME));
 		default ->
-			Stream.of(new TestEnironmentInvocationContext(S4HanaTestConstants.MOCK_SERVER_CONTEXT_DISPLAY_NAME));
+			Stream.of(new TestEnvironmentInvocationContext(S4HanaTestConstants.MOCK_SERVER_CONTEXT_DISPLAY_NAME));
 		};
 	}
 }

--- a/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/context/MultiEnvironmentContextProvider.java
+++ b/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/context/MultiEnvironmentContextProvider.java
@@ -17,8 +17,12 @@ public class MultiEnvironmentContextProvider implements TestTemplateInvocationCo
 
 	@Override
 	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
-		return Stream.of(new TestEnironmentInvocationContext(S4HanaTestConstants.REAL_CALL_CONTEXT_DISPLAY_NAME),
-				new TestEnironmentInvocationContext(S4HanaTestConstants.MOCK_SERVER_CONTEXT_DISPLAY_NAME));
+		String testEnv = System.getProperty(S4HanaTestConstants.END_TO_END_TESTING_ENVIRONMENT_KEY);
+		return switch (testEnv) {
+		case S4HanaTestConstants.END_TO_END_TESTING_ENVIRONMENT_VALUE ->
+			Stream.of(new TestEnironmentInvocationContext(S4HanaTestConstants.REAL_CALL_CONTEXT_DISPLAY_NAME));
+		default ->
+			Stream.of(new TestEnironmentInvocationContext(S4HanaTestConstants.MOCK_SERVER_CONTEXT_DISPLAY_NAME));
+		};
 	}
-
 }

--- a/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/context/TestEnvironmentInvocationContext.java
+++ b/S4HANA-test/src_test/com/axonivy/connector/hana/integration/test/context/TestEnvironmentInvocationContext.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 
-public class TestEnironmentInvocationContext implements TestTemplateInvocationContext {
+public class TestEnvironmentInvocationContext implements TestTemplateInvocationContext {
 	private String contextDisplayName;
 
-	public TestEnironmentInvocationContext(String contextDisplayName) {
+	public TestEnvironmentInvocationContext(String contextDisplayName) {
 		super();
 		this.contextDisplayName = contextDisplayName;
 	}


### PR DESCRIPTION
Introduced a new GitHub Actions workflow for end-to-end (E2E) testing and updated existing CI/CD workflows to use explicit permissions. Enhanced the test configuration to support a 'testEnvironment' property, allowing tests to run in different environments based on this setting. Updated test constants and context provider logic to handle E2E environment selection.